### PR TITLE
stick footer to bottom

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,7 +2,7 @@
 const today = new Date();
 ---
 
-<footer class="footer footer-center block mb-5 pt-10">
+<footer class="footer footer-center block mb-5 pt-10 sticky top-[100vh]">
   <div class="pb-2">
     &copy; {today.getFullYear()} Manuel Ernesto
   </div>


### PR DESCRIPTION
Simple css change to keep the footer in the bottom even for short pages. Completely optional and by each user's discretion, but I find it prettier personally.