### PR TITLE
fix to represent blog posts as articles in opengraph data

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -7,9 +7,10 @@ export interface Props {
 	title: string;
 	description: string;
 	image?: string;
+	ogType?: string;
 }
 
-const { title, description, image = '/social_img.png' } = Astro.props;
+const { title, description, image = '/social_img.png', ogType = 'website' } = Astro.props;
 ---
 
 <!-- Global Metadata -->
@@ -24,7 +25,7 @@ const { title, description, image = '/social_img.png' } = Astro.props;
 <meta name="description" content={description} />
 
 <!-- Open Graph / Facebook -->
-<meta property="og:type" content="website" />
+<meta property="og:type" content={ogType} />
 <meta property="og:url" content={Astro.url} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,13 +6,13 @@ import SideBar from "../components/SideBar.astro";
 
 import { SITE_TITLE, SITE_DESCRIPTION } from "../config";
 
-const { image, title = SITE_TITLE, description = SITE_DESCRIPTION, includeSidebar = true, sideBarActiveItemID } = Astro.props;
+const { image, title = SITE_TITLE, description = SITE_DESCRIPTION, includeSidebar = true, sideBarActiveItemID, ogType } = Astro.props;
 ---
 
 <!DOCTYPE html>
 <html lang="en" data-theme="lofi">
   <head>
-    <BaseHead title={title} description={description} image={image} />
+    <BaseHead title={title} description={description} image={image}, ogType={ogType} />
   </head>
   <body>
     <div class="bg-base-100 drawer lg:drawer-open">

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -12,7 +12,7 @@ const displayDate = dayjs(pubDate).format("ll")
 import { Image } from "astro:assets";
 ---
 
-<BaseLayout title={title} description={description} image={heroImage}>
+<BaseLayout title={title} description={description} image={heroImage}, ogType="article">
   <main class="md:flex md:justify-center">
     <article class="prose prose-lg max-w-[750px] prose-img:mx-auto">
       {heroImage && <Image width={750} height={422} format="webp" src={heroImage} alt={title} class="w-full mb-6" />}


### PR DESCRIPTION
This resolved some opengraph image issues for me when sharing my blog posts. Adds an ogType prop to unhardcode the "website" opengraph type which allows blog posts to be properly categorized as "article" but for everything else defaults to website. Flexible enough to support other opengraph types as well.